### PR TITLE
adding data collection changes

### DIFF
--- a/aml_config/conda_dependencies.yml
+++ b/aml_config/conda_dependencies.yml
@@ -19,3 +19,5 @@ dependencies:
     # Helper utilities for dealing with Azure ML Workbench Assets.
     - https://azuremldownloads.blob.core.windows.net/wheels/latest/azureml.assets-1.0.0-py3-none-any.whl?sv=2016-05-31&si=ro-2017&sr=c&sig=xnUdTm0B%2F%2FfknhTaRInBXyu2QTTt8wA3OsXwGVgU%2BJk%3D
 
+    # Library for collecting data from operationalized models
+    - azureml.datacollector==0.1.0a13

--- a/aml_config/docker-python.compute
+++ b/aml_config/docker-python.compute
@@ -1,4 +1,4 @@
 type: "localdocker"
-baseDockerImage: "microsoft/mmlspark:plus-0.7.dev7_2.gcfbc920"
+baseDockerImage: "microsoft/mmlspark:plus-0.7.9"
 #nativeSharedDirectory: "~/.azureml/share/"
 #sharedVolumes: true

--- a/aml_config/docker-spark.compute
+++ b/aml_config/docker-spark.compute
@@ -1,4 +1,4 @@
 type: "localdocker"
-baseDockerImage: "microsoft/mmlspark:plus-0.7.dev7_2.gcfbc920"
+baseDockerImage: "microsoft/mmlspark:plus-0.7.9"
 #nativeSharedDirectory: "~/.azureml/share/"
 #sharedVolumes: true

--- a/iris_score.py
+++ b/iris_score.py
@@ -2,15 +2,32 @@
 # Creates the schema, and holds the init and run functions needed to 
 # operationalize the Iris Classification sample
 
+# Import data collection library. Only supported for docker mode.
+# Functionality will be ignored when package isn't found
+try:
+    from azureml.datacollector import ModelDataCollector
+except ImportError:
+    print("Data collection is currently only supported in docker mode. May be disabled for local mode.")
+    # Mocking out model data collector functionality
+    class ModelDataCollector(object):
+        def nop(*args, **kw): pass
+        def __getattr__(self, _): return self.nop
+        def __init__(self, *args, **kw): return None
+    pass
+
 # Prepare the web service definition by authoring
 # init() and run() functions. Test the functions
 # before deploying the web service.
 def init():
+    global inputs_dc, prediction_dc
     from sklearn.externals import joblib
 
     # load the model file
     global model
     model = joblib.load('model.pkl')
+
+    inputs_dc = ModelDataCollector("model.pkl", identifier="inputs")
+    prediction_dc = ModelDataCollector("model.pkl", identifier="prediction")
 
 def run(input_df):
     import json
@@ -21,8 +38,10 @@ def run(input_df):
     random_state = np.random.RandomState(0)
     n_samples, n_features = input_df.shape
     input_df = np.c_[input_df, random_state.randn(n_samples, n)]
+    inputs_dc.collect(input_df)
 
     pred = model.predict(input_df)
+    prediction_dc.collect(pred)
     return json.dumps(str(pred[0]))
 
 def main():
@@ -32,6 +51,9 @@ def main():
   import pandas
   
   df = pandas.DataFrame(data=[[3.0, 3.6, 1.3, 0.25]], columns=['sepal length', 'sepal width','petal length','petal width'])
+
+  # Turn on data collection debug mode to view output in stdout
+  os.environ["AML_MODEL_DC_DEBUG"] = 'true'
 
   # Test the output of the functions
   init()


### PR DESCRIPTION
This changes allow for the model data collection module to be used and tested within Workbench in docker mode. The data collection library only has Windows and Linux versions currently, so we aren't supporting local mode (Mac) for public preview.

Data collection lines will be ignored if there are any problems importing the package (most likely if iris_score.py tries to run in local mode where the package isn't installed).